### PR TITLE
Fixed multiple .so files at same path issue for (Android)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,11 +43,6 @@ android {
             path "CMakeLists.txt"
         }
     }
-    sourceSets {
-        main {
-            jniLibs.srcDirs = ['./lib']
-        }
-    }
 }
 
 dependencies {


### PR DESCRIPTION
This removed block was creating *.so files twice and was blocking app building process. By removing this block error has been resolved.

For more details, please read:
[https://developer.android.com/studio/releases/gradle-plugin#cmake-imported-targets](https://developer.android.com/studio/releases/gradle-plugin#cmake-imported-targets)